### PR TITLE
Make watch messages into responses

### DIFF
--- a/src/irmin-client/client.ml
+++ b/src/irmin-client/client.ml
@@ -168,14 +168,17 @@ struct
           recv t name Cmd.res_t)
 
   let recv_commit_diff (t : t) =
+    let* _status = Conn.Response.read_header t.conn in
     Conn.read t.conn (Irmin.Diff.t Commit.t) >|= Error.unwrap "recv_commit_diff"
 
   let recv_branch_diff (t : t) =
+    let* _status = Conn.Response.read_header t.conn in
     Conn.read t.conn
       (Irmin.Type.pair Store.Branch.t (Irmin.Diff.t Store.commit_key_t))
     >|= Error.unwrap "recv_branch_diff"
 
   let recv_branch_key_diff (t : t) =
+    let* _status = Conn.Response.read_header t.conn in
     Conn.read t.conn (Irmin.Diff.t Store.commit_key_t)
     >|= Error.unwrap "recv_branch_key_diff"
 

--- a/src/irmin-server-internal/command_backend.ml
+++ b/src/irmin-server-internal/command_backend.ml
@@ -441,6 +441,7 @@ struct
               let diff_t = Irmin.Diff.t Store.commit_key_t in
               Lwt.catch
                 (fun () ->
+                  let* () = Conn.Response.write_header conn { status = 0 } in
                   let* () =
                     Conn.write conn
                       (Irmin.Type.pair Store.Branch.t diff_t)
@@ -473,6 +474,7 @@ struct
               let diff_t = Irmin.Diff.t Store.commit_key_t in
               Lwt.catch
                 (fun () ->
+                  let* () = Conn.Response.write_header conn { status = 0 } in
                   let* () = Conn.write conn diff_t diff in
                   IO.flush conn.oc)
                 (fun _ -> Lwt.return_unit))


### PR DESCRIPTION
The problem seen in https://github.com/mirage/irmin-server/pull/48#issuecomment-1141499709 is due to a slight simplification that the websocket layer over the top of the flow layer makes, namely all messages are either the initial handshake or a response. You can see this here:

https://github.com/patricoferris/irmin-server/blob/7f1930385840882bddc0cc5af583a5c55034da0c/src/irmin-server/server.ml#L220-L221

For the most part all communication follows these two formats, except for watch messages which omit the status character. The simplest fix is to make the messages into well-formed responses. Previously, the diff was not being sent because we were blocked on the "reading exactly" a lot of bytes because we misread the message.